### PR TITLE
Using FreeRDP tag 2.0.0 instead of the master

### DIFF
--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -163,7 +163,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
-                    "branch": "master"
+                    "tag": "2.0.0",
+                    "commit": "5ab2bed8749747b8e4b2ed431fd102bc726be684"
                 }
             ],
             "modules": [


### PR DESCRIPTION
The FreeRDP team has tagged the version 2.0.0, till it won't be required to switch to the version 3, we prefer to use the release 2.0.0