### PR TITLE
Revert "Update to GNOME 3.38"

### DIFF
--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.remmina.Remmina",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "3.36",
     "sdk": "org.gnome.Sdk",
     "command": "remmina",
     "cleanup": [


### PR DESCRIPTION
Reverts flathub/org.remmina.Remmina#34

Failed to load plugin: /app/lib/remmina/plugins/remmina-plugin-rdp.so.
Error: libdav1d.so.2: cannot open shared object file: No such file or directory
