### PR TITLE
GNOME 40 runtime and other updates

### DIFF
--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -445,7 +445,7 @@
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
                     "tag": "2.4.0",
-                    "commit": "c3df0be63953ed98525d9b736ba878ad733de059",
+                    "commit": "f797e200a2cd47fd42318359b8ae4d46e6507eec",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"

--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.remmina.Remmina",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.38",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "remmina",
     "cleanup": [
@@ -189,27 +189,6 @@
                             }
                         }
                     ]
-                }
-            ]
-        },
-        {
-            "name": "nxproxy",
-            "no-autogen": true,
-            "make-args": [
-                "build-lite",
-                "PREFIX=${FLATPAK_DEST}"
-            ],
-            "install-rule": "install-lite",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/ArcticaProject/nx-libs.git",
-                    "tag": "3.5.99.26",
-                    "commit": "0e2b7971343845248353f6d8503e28506e9536ea",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^([\\d.]+)$"
-                    }
                 }
             ]
         },
@@ -440,72 +419,6 @@
             ]
         },
         {
-            "name": "xephyr",
-            "config-opts": [
-                "--enable-kdrive",
-                "--enable-kdrive-evdev",
-                "--disable-kdrive-kbd",
-                "--disable-kdrive-mouse",
-                "--enable-xephyr",
-                "--disable-xorg",
-                "--disable-xvfb",
-                "--disable-xnest",
-                "--disable-xquartz",
-                "--disable-xwayland",
-                "--disable-standalone-xpbproxy",
-                "--disable-xwin",
-                "--disable-xfake",
-                "--disable-xfbdev",
-                "--disable-dmx",
-                "--with-fontrootdir=/usr/share/fonts",
-                "--with-xkb-bin-directory=/usr/bin",
-                "--with-xkb-path=/usr/share/X11/xkb",
-                "--with-xkb-output=/var/lib/xkb"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://xorg.freedesktop.org/releases/individual/xserver/xorg-server-1.16.4.tar.bz2",
-                    "sha256": "abb6e1cc9213a9915a121f48576ff6739a0b8cdb3d32796f9a7743c9a6efc871"
-                }
-            ],
-            "modules": [
-                {
-                    "name": "libfontenc",
-                    "config-opts": [
-                        "--with-fontrootdir=/usr/share/fonts"
-                    ],
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "https://xorg.freedesktop.org/releases/individual/lib/libfontenc-1.1.4.tar.bz2",
-                            "sha256": "2cfcce810ddd48f2e5dc658d28c1808e86dcf303eaff16728b9aa3dbc0092079",
-                            "x-checker-data": {
-                                "type": "anitya",
-                                "project-id": 1613,
-                                "url-template": "https://xorg.freedesktop.org/releases/individual/lib/libfontenc-$version.tar.bz2"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "name": "libXfont",
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "https://xorg.freedesktop.org/releases/individual/lib/libXfont-1.5.4.tar.bz2",
-                            "sha256": "1a7f7490774c87f2052d146d1e0e64518d32e6848184a18654e8d0bb57883242",
-                            "x-checker-data": {
-                                "type": "anitya",
-                                "project-id": 1776,
-                                "url-template": "https://xorg.freedesktop.org/releases/individual/lib/libXfont-$version.tar.bz2"
-                            }
-                        }
-                    ]
-                }
-            ]
-        },
-        {
             "name": "freerdp",
             "buildsystem": "cmake-ninja",
             "cleanup": [],
@@ -531,7 +444,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
-                    "tag": "2.3.2",
+                    "tag": "2.4.0",
                     "commit": "c3df0be63953ed98525d9b736ba878ad733de059",
                     "x-checker-data": {
                         "type": "git",


### PR DESCRIPTION
- Runtime 40
- FreeRDP 2.4.0
- Libsodium stable
- Removed Xephyr dependencies

Closes issue #62
Closes #72 
Closes #74 

Signed-off-by: Antenore Gatta (tmow) <antenore@simbiosi.org>