### PR TITLE
Update GNOME runtime and some dependencies

### DIFF
--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.remmina.Remmina",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "remmina",
     "cleanup": [
@@ -47,7 +47,7 @@
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "20.08",
+            "version": "21.08",
             "add-ld-path": ".",
             "no-autodownload": false,
             "autodelete": false
@@ -93,13 +93,14 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/OpenPrinting/cups.git",
-                    "tag": "v2.3.3",
-                    "commit": "82e3ee0e3230287b76a76fb8f16b92ca6e50b444",
+                    "type": "archive",
+                    "url": "https://github.com/OpenPrinting/cups/archive/refs/tags/v2.3.3op2.tar.gz",
+                    "sha256": "5d7dc1f05cde3d5c31d3a2b3b54d519ca74e42c1b25df1add9a1802cd13c65ad",
                     "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
+                        "type": "anitya",
+                        "project-id": 380,
+                        "stable-only": false,
+                        "url-template": "https://github.com/OpenPrinting/cups/archive/refs/tags/v$version.tar.gz"
                     }
                 }
             ]
@@ -111,7 +112,12 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/gtk-vnc/1.2/gtk-vnc-1.2.0.tar.xz",
-                    "sha256": "7aaf80040d47134a963742fb6c94e970fcb6bf52dc975d7ae542b2ef5f34b94a"
+                    "sha256": "7aaf80040d47134a963742fb6c94e970fcb6bf52dc975d7ae542b2ef5f34b94a",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13142,
+                        "url-template": "https://download.gnome.org/sources/gtk-vnc/1.2/gtk-vnc-$version.tar.xz"
+                    }
                 }
             ]
         },
@@ -122,8 +128,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/vte.git",
-                    "tag": "0.65.91",
-                    "commit": "757fc880364e5100dfaaea27d880ed488897b16b",
+                    "tag": "0.66.0",
+                    "commit": "956d3bbd265279c296c56d9fb5ada1fee94768ee",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"


### PR DESCRIPTION
@antenore This one also has a security related update.

Pay close attention to Cups. They had some security hotfixes but their slugs did not meet the Git data checker. As such, I replaced it for Anitya so that they'll be flagged earlier in the future.