### PR TITLE
Revert flatpak to use FreeRDP2

### DIFF
--- a/org.remmina.Remmina-local.json
+++ b/org.remmina.Remmina-local.json
@@ -21,7 +21,7 @@
         "--share=ipc",
         "--share=network",
         "--socket=cups",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=pcsc",
         "--socket=pulseaudio",
         "--socket=ssh-auth",
@@ -494,37 +494,6 @@
             ]
         },
         {
-            "name": "pkcs11-helper",
-            "buildsystem": "autotools",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/OpenSC/pkcs11-helper.git",
-                    "tag": "pkcs11-helper-1.29.0",
-                    "commit": "2306f896c2f3c147792300155316fd65825aabad"
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "autogen.sh",
-                    "commands": [
-                        "autoreconf -vfi"
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "krb5",
-            "buildsystem": "autotools",
-            "subdir": "src",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://kerberos.org/dist/krb5/1.21/krb5-1.21.1.tar.gz",
-                    "sha256": "7881c3aaaa1b329bd27dbc6bf2bf1c85c5d0b6c7358aff2b35d513ec2d50fa1f"
-                }
-            ]
-        },
-        {
             "name": "freerdp",
             "buildsystem": "cmake-ninja",
             "cleanup": [],
@@ -546,19 +515,14 @@
                 "-DWITH_FFMPEG:BOOL=ON",
                 "-DWITH_OSS:BOOL=OFF",
                 "-DWITH_PULSE:BOOL=ON",
-                "-DWITH_LIBSYSTEMD:BOOL=OFF",
-                "-DWITH_FUSE:BOOL=OFF",
-                "-DWITH_WEBVIEW:BOOL=OFF",
-                "-DWITH_PKCS11:BOOL=ON",
-                "-DWITH_KRB5:BOOL=ON",
-                "-DALLOW_IN_SOURCE_BUILD=ON"
+                "-DWITH_LIBSYSTEMD:BOOL=OFF"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
-                    "tag": "3.2.0",
-                    "commit": "bb87d4ca5072c40e83ed92130a6674bf245d1f2f",
+                    "tag": "2.11.2",
+                    "commit": "a38c1be9eee39a9bc22b511fffe96e63fdf8ebe7",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
@@ -578,7 +542,7 @@
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE:STRING=Debug",
                 "-DCMAKE_INSTALL_LIBDIR:PATH=lib",
-                "-DWITH_FREERDP3:BOOL=ON",
+                "-DWITH_FREERDP3:BOOL=OFF",
                 "-DWITH_GVNC:BOOL=ON",
                 "-DWITH_CUPS:BOOL=ON",
                 "-DWITH_PYTHONLIBS:BOOL=ON",

--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -21,7 +21,7 @@
         "--share=ipc",
         "--share=network",
         "--socket=cups",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=pcsc",
         "--socket=pulseaudio",
         "--socket=ssh-auth",
@@ -485,37 +485,6 @@
             ]
         },
         {
-            "name": "pkcs11-helper",
-            "buildsystem": "autotools",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/OpenSC/pkcs11-helper.git",
-                    "tag": "pkcs11-helper-1.29.0",
-                    "commit": "2306f896c2f3c147792300155316fd65825aabad"
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "autogen.sh",
-                    "commands": [
-                        "autoreconf -vfi"
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "krb5",
-            "buildsystem": "autotools",
-            "subdir": "src",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://kerberos.org/dist/krb5/1.21/krb5-1.21.1.tar.gz",
-                    "sha256": "7881c3aaaa1b329bd27dbc6bf2bf1c85c5d0b6c7358aff2b35d513ec2d50fa1f"
-                }
-            ]
-        },
-        {
             "name": "freerdp",
             "buildsystem": "cmake-ninja",
             "cleanup": [],
@@ -537,19 +506,14 @@
                 "-DWITH_FFMPEG:BOOL=ON",
                 "-DWITH_OSS:BOOL=OFF",
                 "-DWITH_PULSE:BOOL=ON",
-                "-DWITH_LIBSYSTEMD:BOOL=OFF",
-                "-DWITH_FUSE:BOOL=OFF",
-                "-DWITH_WEBVIEW:BOOL=OFF",
-                "-DWITH_PKCS11:BOOL=ON",
-                "-DWITH_KRB5:BOOL=ON",
-                "-DALLOW_IN_SOURCE_BUILD=ON"
+                "-DWITH_LIBSYSTEMD:BOOL=OFF"
             ],
             "sources": [
                 {
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
-                    "tag": "3.2.0",
-                    "commit": "bb87d4ca5072c40e83ed92130a6674bf245d1f2f",
+                    "tag": "2.11.2",
+                    "commit": "a38c1be9eee39a9bc22b511fffe96e63fdf8ebe7",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
@@ -568,7 +532,7 @@
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE:STRING=Release",
                 "-DCMAKE_INSTALL_LIBDIR:PATH=lib",
-                "-DWITH_FREERDP3:BOOL=ON",
+                "-DWITH_FREERDP3:BOOL=OFF",
                 "-DWITH_GVNC:BOOL=ON",
                 "-DWITH_CUPS:BOOL=ON",
                 "-DWITH_PYTHONLIBS:BOOL=ON",


### PR DESCRIPTION
Several users had issues with RDP connections after upgrading to the Remmina flatpak version using FreeRDP3, so reverting back to FreeRDP2 for the Remmina flatpak.