### PR TITLE
Update libsodium and others

### DIFF
--- a/org.remmina.Remmina-local.json
+++ b/org.remmina.Remmina-local.json
@@ -93,8 +93,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://xorg.freedesktop.org/archive/individual/lib/libXmu-1.2.0.tar.xz",
-                    "sha256": "072026fe305889538e5b0c5f9cbcd623d2c27d2b85dcd37ca369ab21590b6963",
+                    "url": "https://xorg.freedesktop.org/archive/individual/lib/libXmu-1.2.1.tar.xz",
+                    "sha256": "fcb27793248a39e5fcc5b9c4aec40cc0734b3ca76aac3d7d1c264e7f7e14e8b2",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1785,
@@ -134,8 +134,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/OpenPrinting/cups/archive/refs/tags/v2.4.7.tar.gz",
-                    "sha256": "9b9a126018462f7326baa828bdf861939e37e00bc63884e03129b3f3360c44fe",
+                    "url": "https://github.com/OpenPrinting/cups/archive/refs/tags/v2.4.10.tar.gz",
+                    "sha256": "f51b9edd631db1830b967101b51f0045c8c239ae799dff89f0399f3e47a95c02",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 380,
@@ -168,8 +168,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/vte.git",
-                    "tag": "0.76.0",
-                    "commit": "3c29bfef30c34afec4982ba5ec37f944cfacbba2",
+                    "tag": "0.76.3",
+                    "commit": "036bc3ddcbb56f05c6ca76712a53b89dee1369e2",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
@@ -415,12 +415,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/jedisct1/libsodium/archive/1.0.19.tar.gz",
-                    "sha256": "1d281a8a5e299a38e5c16ff60f293bba0796dc0fda8e49bc582d4bc1935572ed",
+                    "url": "https://download.libsodium.org/libsodium/releases/libsodium-1.0.20.tar.gz",
+                    "sha256": "ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1728,
-                        "url-template": "https://github.com/jedisct1/libsodium/archive/$version.tar.gz"
+                        "url-template": "https://download.libsodium.org/libsodium/releases/libsodium-$version.tar.gz"
                     }
                 }
             ],

--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -125,8 +125,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/OpenPrinting/cups/archive/refs/tags/v2.4.9.tar.gz",
-                    "sha256": "b01fe197e9e81c1516412c73c782f5d9fef671ce998e3ee207cdf6e09155b76f",
+                    "url": "https://github.com/OpenPrinting/cups/archive/refs/tags/v2.4.10.tar.gz",
+                    "sha256": "f51b9edd631db1830b967101b51f0045c8c239ae799dff89f0399f3e47a95c02",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 380,
@@ -159,8 +159,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/vte.git",
-                    "tag": "0.76.0",
-                    "commit": "3c29bfef30c34afec4982ba5ec37f944cfacbba2",
+                    "tag": "0.76.3",
+                    "commit": "036bc3ddcbb56f05c6ca76712a53b89dee1369e2",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^([\\d.]+)$"
@@ -403,12 +403,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/jedisct1/libsodium/archive/1.0.19.tar.gz",
-                    "sha256": "1d281a8a5e299a38e5c16ff60f293bba0796dc0fda8e49bc582d4bc1935572ed",
+                    "url": "https://download.libsodium.org/libsodium/releases/libsodium-1.0.20.tar.gz",
+                    "sha256": "ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1728,
-                        "url-template": "https://github.com/jedisct1/libsodium/archive/$version.tar.gz"
+                        "url-template": "https://download.libsodium.org/libsodium/releases/libsodium-$version.tar.gz"
                     }
                 }
             ],


### PR DESCRIPTION
Remmina pipelines have been failing due to mismatching libsodium hashes, so that along with several other dependencies with general updates have been updated here.