### PR TITLE
Update runtime to GNOME 48

### DIFF
--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.remmina.Remmina",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "remmina",
     "cleanup": [


### PR DESCRIPTION
GNOME 46 is now deprecated. Until it is updated, GNOME Software will claim it has "Stopped Receiving Updates".