### PR TITLE
Fix smart card functionality on hosts running PCSC >= 2.3.0

### DIFF
--- a/org.remmina.Remmina-local.json
+++ b/org.remmina.Remmina-local.json
@@ -241,6 +241,7 @@
             "name": "pcsc",
             "config-opts": [
                 "--disable-libsystemd",
+                "--disable-polkit",
                 "--enable-pic",
                 "--disable-libusb",
                 "--enable-shared",
@@ -250,12 +251,16 @@
                 {
                     "type": "git",
                     "url": "https://github.com/LudovicRousseau/PCSC.git",
-                    "tag": "pcsc-1.9.0",
-                    "commit": "e796a0f12fbefa459bff0d25e27089615fa91f21",
+                    "tag": "2.3.3",
+                    "commit": "3ef55e02979de6834015b380c1d21671eeb4e9f5",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^pcsc-([\\d.]+)$"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/pcsc-lite-protocol.patch"
                 }
             ]
         },

--- a/org.remmina.Remmina.json
+++ b/org.remmina.Remmina.json
@@ -235,6 +235,7 @@
             "name": "pcsc",
             "config-opts": [
                 "--disable-libsystemd",
+                "--disable-polkit",
                 "--enable-pic",
                 "--disable-libusb",
                 "--enable-shared",
@@ -244,12 +245,16 @@
                 {
                     "type": "git",
                     "url": "https://github.com/LudovicRousseau/PCSC.git",
-                    "tag": "pcsc-1.9.0",
-                    "commit": "e796a0f12fbefa459bff0d25e27089615fa91f21",
+                    "tag": "2.3.3",
+                    "commit": "3ef55e02979de6834015b380c1d21671eeb4e9f5",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^pcsc-([\\d.]+)$"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/pcsc-lite-protocol.patch"
                 }
             ]
         },

--- a/patches/pcsc-lite-protocol.patch
+++ b/patches/pcsc-lite-protocol.patch
@@ -1,0 +1,28 @@
+diff --git a/src/winscard_clnt.c b/src/winscard_clnt.c
+index b9c900e..4b84ee8 100644
+--- a/src/winscard_clnt.c
++++ b/src/winscard_clnt.c
+@@ -600,7 +600,22 @@ static LONG SCardEstablishContextTH(DWORD dwScope,
+ 			goto cleanup;
+ 		}
+ 
+-		Log3(PCSC_LOG_INFO, "Server is protocol version %d:%d",
++		if (veStr.rv != SCARD_S_SUCCESS){
++			if (veStr.minor == 4 && PROTOCOL_VERSION_MINOR == 5){
++				Log1(PCSC_LOG_INFO, "Reading from server again, mismatch");
++
++				veStr.major = PROTOCOL_VERSION_MAJOR;
++				veStr.minor = 4;
++				veStr.rv = SCARD_S_SUCCESS;
++				rv = MessageSendWithHeader(CMD_VERSION, dwClientID, sizeof(veStr),
++					&veStr);
++
++				Log1(PCSC_LOG_INFO, "Sent to server");
++				rv = MessageReceive(&veStr, sizeof(veStr), dwClientID);
++			}
++		}
++
++		Log3(PCSC_LOG_INFO, "Negotiated protocol version %d:%d",
+ 			veStr.major, veStr.minor);
+ 
+ 		if (veStr.rv != SCARD_S_SUCCESS)


### PR DESCRIPTION
Fixes smart card functionality for hosts running PCSC >= 2.3.0. At the same time, adds a patch that enables version negotiation in order to preserve functionality for hosts running older PCSC.

Borrowed from the org.keepassxc.KeePassXC package:
- https://github.com/flathub/org.keepassxc.KeePassXC/pull/148
- https://github.com/flathub/org.keepassxc.KeePassXC/commit/23dacfd4af4fc11ad2e5751bf9db6ba0d43e2760

References:
- https://blog.apdu.fr/posts/2022/02/accessing-smart-cards-from-inside/