### PR TITLE
Disable external data checker

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-	"automerge-flathubbot-prs": true
+	"disable-external-data-checker": true
 }


### PR DESCRIPTION
There are too many PR created by flathubbot that failed.

Disable x-checker until maintenance resumes

https://github.com/flathub/org.remmina.Remmina/pulls?q=is%3Apr+author%3Aflathubbot+is%3Aclosed